### PR TITLE
Add the build order as a graph

### DIFF
--- a/buildSrc/src/main/kotlin/io/micronaut/build/ProjectGraphBuilder.kt
+++ b/buildSrc/src/main/kotlin/io/micronaut/build/ProjectGraphBuilder.kt
@@ -79,28 +79,36 @@ abstract class ProjectGraphBuilder : DefaultTask() {
         if (missingPlatformDependencies.isNotEmpty()) {
             warnings.add("[WARNING] The following modules are not included in the platform: $missingPlatformDependencies")
         }
-        buildOrderFile.printWriter(charset("UTF-8")).use { writer ->
-            val comparator: (o1: String, o2: String) -> Int = { p1, p2 ->
-                val deps1 = p1.transitiveDeps(projectToDependencies)
-                val deps2 = p2.transitiveDeps(projectToDependencies)
-                if (deps1.contains(p2) && deps2.contains(p1)) {
-                    warnings.add("[WARNING] Circular dependency between $p1 and $p2")
-                }
-                if (deps1.contains(p2)) {
-                    1
-                } else if (deps2.contains(p1)) {
-                    -1
-                } else {
-                    deps1.size.compareTo(deps2.size)
-                }
+        val cycles = mutableSetOf<Pair<String, String>>()
+        val comparator: (o1: String, o2: String) -> Int = { p1, p2 ->
+            val deps1 = p1.transitiveDeps(projectToDependencies)
+            val deps2 = p2.transitiveDeps(projectToDependencies)
+            if (deps1.contains(p2) && deps2.contains(p1)) {
+                warnings.add("[WARNING] Circular dependency between $p1 and $p2")
+                cycles.add(Pair(p1, p2))
             }
+            if (deps1.contains(p2)) {
+                1
+            } else if (deps2.contains(p1)) {
+                -1
+            } else {
+                deps1.size.compareTo(deps2.size)
+            }
+        }
+        buildOrderFile.printWriter(charset("UTF-8")).use { txtWriter ->
             val projects = projectToDependencies.keys.sortedWith(comparator)
             warnings.forEach {
                 System.err.println(it)
-                writer.println(it)
+                txtWriter.println(it)
             }
-            writeBuildOrderFile(writer, projects, comparator)
-            writeBuildErrors(reportsDir, writer)
+            File(temporaryDir, "build-order-graph.dot").also {
+                it.printWriter(charset("UTF-8")).use { dotWriter ->
+                    writeBuildOrder(txtWriter, dotWriter, projects, comparator, cycles)
+                }
+                invokeGraphviz(outputDir, "build-order", it)
+//                it.delete()
+            }
+            writeBuildErrors(reportsDir, txtWriter)
         }
     }
 
@@ -113,28 +121,83 @@ abstract class ProjectGraphBuilder : DefaultTask() {
         }
     }
 
-    private fun writeBuildOrderFile(writer: PrintWriter, projects: List<String>, comparator: (o1: String, o2: String) -> Int) {
-        writer.println("Projects should be buildable in the following order, if tests are not executed:")
-        val aggregate = mutableListOf<String>()
+    private fun writeBuildOrder(
+        textFile: PrintWriter,
+        dotFile: PrintWriter,
+        projects: List<String>,
+        comparator: (o1: String, o2: String) -> Int,
+        cycles: Set<Pair<String, String>>
+    ) {
+        textFile.println("Projects should be buildable in the following order, if tests are not executed:")
+        dotFile.println("digraph build_order {")
+        dotFile.println("  compound=true;")
+        dotFile.println("  label = \"Projects should be buildable in the following order, if tests are not executed\";")
+        dotFile.println("  labelloc = \"t\";")
+        dotFile.println("  node [fontsize=14 fontname=\"Verdana\"];")
+        val cluster = mutableListOf<String>()
+        var previous: String? = null
+        var previousNode: String? = null
         projects.forEach { project ->
-            if (aggregate.isEmpty()) {
-                aggregate.add(project)
-            } else if (aggregate.all { comparator(it, project) == 0 }) {
-                aggregate.add(project)
+            if (cluster.isEmpty()) {
+                cluster.add(project)
+            } else if (cluster.all { comparator(it, project) == 0 }) {
+                cluster.add(project)
             } else {
-                writer.println("  - ${aggregate.joinToString(", ")}")
-                aggregate.clear()
-                aggregate.add(project)
+                val id = writeCluster(cluster, dotFile)
+                val middle = cluster[cluster.size / 2]
+                if (previous != null) {
+                    val head = if (id.startsWith("cluster_")) "lhead=$id" else ""
+                    val tail = if (previous!!.startsWith("cluster_")) "ltail=$previous" else ""
+                    if (!cycles.any { (p1, p2) -> (p1 == previousNode && p2 == middle) || (p1 == middle && p2 == previousNode) }) {
+                        dotFile.println("  \"$previousNode\" -> \"$middle\" [$head $tail];")
+                    }
+                }
+                previousNode = middle
+                textFile.println("  - ${cluster.joinToString(", ")}")
+                cluster.clear()
+                cluster.add(project)
+                previous = id
             }
         }
-        if (aggregate.isNotEmpty()) {
-            writer.println("  - ${aggregate.joinToString(", ")}")
+        if (cluster.isNotEmpty()) {
+            val id = writeCluster(cluster, dotFile)
+            val middle = cluster[cluster.size / 2]
+            if (previous != null) {
+                val head = if (id.startsWith("cluster_")) "lhead=$id" else ""
+                val tail = if (previous!!.startsWith("cluster_")) "ltail=$previous" else ""
+                if (!cycles.any { (p1, p2) -> (p1 == previousNode && p2 == middle) || (p1 == middle && p2 == previousNode) }) {
+
+                    dotFile.println("  \"$previousNode\" -> \"$middle\" [$head $tail];")
+                }
+            }
+            textFile.println("  - ${cluster.joinToString(", ")}")
         }
+        cycles.forEach { (p1, p2) ->
+            dotFile.println("  \"$p1\" -> \"$p2\" [color=red];")
+        }
+        dotFile.println("}")
+    }
+
+    private fun writeCluster(cluster: MutableList<String>, dotFile: PrintWriter): String {
+        val id: String
+        if (cluster.size > 1) {
+            id = "cluster_${cluster.first()}"
+            dotFile.println("  subgraph $id {")
+            dotFile.println("    label = \"\"")
+            cluster.forEach { dotFile.println("    \"$it\";") }
+            dotFile.println("    color=blue;")
+            dotFile.println("  }")
+        } else {
+            id = cluster.first()
+            dotFile.println("  \"${id}\";")
+        }
+        return id
     }
 
     private fun buildProjectDependenciesMap(reportsDir: File): MutableMap<String, MutableSet<String>> {
         val projectToDependencies = mutableMapOf<String, MutableSet<String>>()
         reportsDir.listFiles().forEach { projectDir ->
+            println("Processing ${projectDir.name}")
             projectDir.listFiles().forEach { dependencyFile ->
                 val dependencies = mutableSetOf<String>()
                 if (dependencyFile.name.endsWith(".txt")) {
@@ -163,8 +226,10 @@ abstract class ProjectGraphBuilder : DefaultTask() {
                 }
             }
             if (error != null && project != null) {
-                errors.add("""Project $project has an error: 
-                    |$error""".trimMargin())
+                errors.add(
+                    """Project $project has an error: 
+                    |$error""".trimMargin()
+                )
             }
         }
         return errors
@@ -187,6 +252,10 @@ abstract class ProjectGraphBuilder : DefaultTask() {
             writer.println("}")
         }
         // Call the dot command to generate the PNG file
+        invokeGraphviz(outputDir, graphName, dotFile)
+    }
+
+    private fun invokeGraphviz(outputDir: File, graphName: String, dotFile: File) {
         execOperations.exec {
             executable = "dot"
             args = listOf("-Tpng", "-o", File(outputDir, "${graphName}.png").absolutePath, dotFile.absolutePath)

--- a/buildSrc/src/main/resources/index.template
+++ b/buildSrc/src/main/resources/index.template
@@ -83,10 +83,12 @@
 </div>
 <div class="row">
     <nav>
-        <li class="item" onclick="showImage(this, 'project-graph.png')">project-graph</li>
+        <li class="item" onclick="showImage(this, 'build-order.png')">Build Order</li>
+        <li class="item" onclick="showImage(this, 'project-graph.png')">Project graph</li>
 {{ITEMS}}
     </nav>
     <div class="image-container">
+        <img id="build-order.png" src="build-order.png">
         <img id="project-graph.png" src="project-graph.png">
 {{IMAGES}}
     </div>
@@ -98,7 +100,7 @@
         var images = Array.from(document.getElementsByClassName("image-container")[0].getElementsByTagName("img")).forEach(i => i.style.display = "none");
         document.getElementById(imageId).style.display = "block";
     }
-    showImage(document.getElementsByClassName("item")[0], "project-graph.png");
+    showImage(document.getElementsByClassName("item")[0], "build-order.png");
 </script>
 </body>
 </html>


### PR DESCRIPTION
The build order file is still generated, but we also add a graph which groups are represented as clusters, and cycles are printed in red in order to make it obvious there are issues.