### PR TITLE
Use GraphQL on CI to get the list of modules

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,9 +29,27 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
+      - name: Fetch all micronaut-projects modules
+        id: module-fetch
+        run: |
+          MODULES=$(gh api graphql --paginate -f query='query {
+            search(query: "user:micronaut-projects archived:false", type: REPOSITORY, first: 100) {
+              nodes {
+                ... on Repository {
+                  name
+                  defaultBranchRef {
+                    name
+                  }
+                }
+              }
+            }
+          }' --template '{{range .data.search.nodes}}{{.name}}{{"@"}}{{.defaultBranchRef.name}}{{","}}{{end}}')
+          echo "MICRONAUT_MODULES=$MODULES" >> $GITHUB_OUTPUT
+
       - name: Execute Gradle build
         run: ./gradlew allReports graphBuilder
         env:
+          MICRONAUT_MODULES: ${{ steps.module-fetch.outputs.MICRONAUT_MODULES }}
           GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -44,7 +44,10 @@ jobs:
               }
             }
           }' --template '{{range .data.search.nodes}}{{.name}}{{"@"}}{{.defaultBranchRef.name}}{{","}}{{end}}')
+          echo "Fetched modules: $MODULES"
           echo "MICRONAUT_MODULES=$MODULES" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Execute Gradle build
         run: ./gradlew allReports graphBuilder

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,77 +2,113 @@ plugins {
     id("io.micronaut.build.license-report")
 }
 
+// When using the environment variable, these are the modules to ignore
+val blockList = listOf(
+    "micronaut-build",
+    "micronaut-build-plugins",
+    "micronaut-comparisons",
+    "micronaut-crac-tests",
+    "micronaut-docs",
+    "micronaut-docs-deploy",
+    "micronaut-docs-index",
+    "micronaut-examples",
+    "micronaut-fuzzing",
+    "micronaut-guides",
+    "micronaut-guides-old",
+    "micronaut-guides-poc",
+    "micronaut-helidon", // Not sure what this is, but it fails locally with permissions errors
+    "micronaut-lambda-todo",
+    "micronaut-maven-plugin",
+    "micronaut-oauth2",
+    "micronaut-profiles",
+    "micronaut-project-template",
+    "micronaut-starter-ui",
+)
+
+// For local dev with no env var, these are the modules to pull
+val defaultModules = listOf(
+    "micronaut-acme",
+    "micronaut-aot",
+    "micronaut-aws",
+    "micronaut-azure",
+    "micronaut-build",
+    "micronaut-cache",
+    "micronaut-camel",
+    "micronaut-cassandra",
+    "micronaut-coherence",
+    "micronaut-core@4.0.x",
+    "micronaut-couchbase",
+    "micronaut-crac",
+    "micronaut-data",
+    "micronaut-discovery-client",
+    "micronaut-elasticsearch",
+    "micronaut-gcp",
+    "micronaut-gradle-plugin",
+    "micronaut-graphql",
+    "micronaut-groovy",
+    "micronaut-grpc",
+    "micronaut-hibernate-validator",
+    "micronaut-ignite",
+    "micronaut-jackson-xml",
+    "micronaut-jms",
+    "micronaut-jmx",
+    "micronaut-kafka",
+    "micronaut-kotlin",
+    "micronaut-kubernetes",
+    "micronaut-liquibase",
+    "micronaut-logging",
+    "micronaut-micrometer",
+    "micronaut-mongodb",
+    "micronaut-mqtt",
+    "micronaut-multitenancy",
+    "micronaut-nats",
+    "micronaut-neo4j",
+    "micronaut-object-storage",
+    "micronaut-openapi",
+    "micronaut-oracle-cloud",
+    "micronaut-picocli",
+    "micronaut-platform",
+    "micronaut-problem-json",
+    "micronaut-pulsar",
+    "micronaut-rabbitmq",
+    "micronaut-reactor",
+    "micronaut-redis",
+    "micronaut-rss",
+    "micronaut-rxjava2",
+    "micronaut-rxjava3",
+    "micronaut-security",
+    "micronaut-serialization",
+    "micronaut-servlet",
+    "micronaut-session",
+    "micronaut-spring",
+    "micronaut-sql",
+    "micronaut-starter",
+    "micronaut-test",
+    "micronaut-test-resources",
+    "micronaut-toml",
+    "micronaut-validation",
+    "micronaut-views",
+)
+
 micronautProjects {
-    listOf(
-        "micronaut-acme",
-        "micronaut-aot",
-        "micronaut-aws",
-        "micronaut-azure",
-        "micronaut-build",
-        "micronaut-cache",
-        "micronaut-camel",
-        "micronaut-cassandra",
-        "micronaut-coherence",
-        "micronaut-core@4.0.x",
-        "micronaut-couchbase",
-        "micronaut-crac",
-        "micronaut-data",
-        "micronaut-discovery-client",
-        "micronaut-elasticsearch",
-        "micronaut-gcp",
-        "micronaut-gradle-plugin",
-        "micronaut-graphql",
-        "micronaut-groovy",
-        "micronaut-grpc",
-        "micronaut-hibernate-validator",
-        "micronaut-ignite",
-        "micronaut-jackson-xml",
-        "micronaut-jms",
-        "micronaut-jmx",
-        "micronaut-kafka",
-        "micronaut-kotlin",
-        "micronaut-kubernetes",
-        "micronaut-liquibase",
-        "micronaut-logging",
-        "micronaut-micrometer",
-        "micronaut-mongodb",
-        "micronaut-mqtt",
-        "micronaut-multitenancy",
-        "micronaut-nats",
-        "micronaut-neo4j",
-        "micronaut-object-storage",
-        "micronaut-openapi",
-        "micronaut-oracle-cloud",
-        "micronaut-picocli",
-        "micronaut-platform",
-        "micronaut-problem-json",
-        "micronaut-pulsar",
-        "micronaut-rabbitmq",
-        "micronaut-reactor",
-        "micronaut-redis",
-        "micronaut-rss",
-        "micronaut-rxjava2",
-        "micronaut-rxjava3",
-        "micronaut-security",
-        "micronaut-serialization",
-        "micronaut-servlet",
-        "micronaut-session",
-        "micronaut-spring",
-        "micronaut-sql",
-        "micronaut-starter",
-        "micronaut-test",
-        "micronaut-test-resources",
-        "micronaut-toml",
-        "micronaut-validation",
-        "micronaut-views",
-    ).map {
-        val (name, branch) = if (it.contains('@')) {
-            it.split('@')
-        } else {
-            listOf(it, "master")
+    project.providers
+        .environmentVariable("MICRONAUT_MODULES") // Env var from GH Action
+        .map { it.split(',') }
+        .map {
+            it
+                .filter { moduleBranch -> moduleBranch.startsWith("micronaut-") } // Has to start with 'micronaut-'
+                .filterNot { moduleBranch -> moduleBranch.contains("-ghsa-") } // Not a security module fork
+                .filterNot { moduleBranch -> blockList.contains(moduleBranch.split("@").first()) }
         }
-        Pair("https://github.com/micronaut-projects/${name}.git", branch)
-    }.forEach {
-        checkout(it.first, it.second)
-    }
+        .getOrElse(defaultModules) // Fallback to the default modules if no env var
+        .map {
+            val (name, branch) = if (it.contains('@')) {
+                it.split('@')
+            } else {
+                listOf(it, "master")
+            }
+            Pair("https://github.com/micronaut-projects/${name}.git", branch)
+        }.forEach {
+            checkout(it.first, it.second)
+        }
 }


### PR DESCRIPTION
This adds a GH Action to fetch the list of modules under our org via GraphQL.

This list is stored as a comma-separated env-var in 'name@default-branch' format, and passed into the build.

We have to then filter this list of modules to remove those that are not part of the Micronaut release cycle.

If there is no env var, then we fall back to using the list of modules as before

I've not tested the GraphQL action on GH, just locally...  Fingers crossed 🤞 