### PR TITLE
Fix incorrectly detected cycle with test resources

### DIFF
--- a/src/init.gradle
+++ b/src/init.gradle
@@ -96,7 +96,10 @@ rootProject {
                         cachedStatus
                     }
                     ['apiElements', 'runtimeElements'].each {
-                        def conf = configurations.findByName(it)
+                        def conf = configurations.findByName("optimized${it.capitalize()}")
+                        if (conf == null) {
+                            conf = configurations.findByName(it)
+                        }
                         if (conf != null) {
                             t.dependencies.addAll(providers.provider {
                                 conf.allDependencies.findAll { it instanceof ExternalModuleDependency }


### PR DESCRIPTION
The test resources server makes use of Micronaut Platform via the Micronaut Gradle plugin, but it uses a snapshot version of the plugin and platform. This will _not_ prevent from releasing, as what we ship is a fat jar which contains all required dependencies, and no dependency on the platform itself.