### PR TITLE
Add implicit dependency from gradle to platform

### DIFF
--- a/buildSrc/src/main/kotlin/io/micronaut/build/ProjectGraphBuilder.kt
+++ b/buildSrc/src/main/kotlin/io/micronaut/build/ProjectGraphBuilder.kt
@@ -292,6 +292,11 @@ abstract class ProjectGraphBuilder : DefaultTask() {
                         allDependencies.split(",").forEach { dependency ->
                             dependencies.add(dependency.toProjectName())
                         }
+                        if (name == "gradle") {
+                            // Add an implicit dependency to platform, which is not captured by the tool
+                            // because it's added at runtime only by the plugin
+                            dependencies.add("platform")
+                        }
                     }
                     if (projectToMetadata.containsKey(name)) {
                         throw IllegalStateException("Duplicate project name: $name, also found in $dependencyFile")


### PR DESCRIPTION
The Gradle plugin depends on Micronaut Platform, but it is not visible as a runtime dependency, because it's a dependency which is added at runtime _when the plugin is applied_. If we released the Gradle plugin simply considering the current graph, then a user applying the plugin would get a SNAPSHOT version of the platform.

This commit updates the report tool to add a dependency so that it's clearly visible.