### PR TITLE
Add basic search/filtering

### DIFF
--- a/buildSrc/src/main/resources/template.html
+++ b/buildSrc/src/main/resources/template.html
@@ -116,6 +116,29 @@
     }
     showImage(document.getElementsByClassName("item")[0], "build-order.png");
 
+    // Basic filtering with no ui...  just type things
+    let search = '';
+    function filter(text) {
+        Array.from(document.getElementsByClassName("item")).forEach(li => {
+            const cell = li.getElementsByTagName("td");
+            if (cell.length === 0) {
+                // Not a module...
+            } else if (cell[0].innerText.includes(text) || text === null) {
+                // make li visible
+                li.style.display = "block";
+            } else {
+                li.style.display = "none";
+            }
+        });
+    }
+    document.addEventListener("keydown", event => {
+        if (event.keyCode >= 65 && event.keyCode <= 90) {
+            search = (search == null ? '' : search) + event.key;
+        } else {
+            search = null;
+        }
+        filter(search);
+    });
 </script>
 </body>
 </html>


### PR DESCRIPTION
I struggled to find the module of interest.
This PR adds a basic search filter to the page.

Just load the page, then type the module name and the list on the left will be filtered to match what you type. Any non a-z character (such as Esc) clears the filter.

No UI, because I couldn't face it.